### PR TITLE
Remove inline calls for automatically inlined functions

### DIFF
--- a/src/entity.jl
+++ b/src/entity.jl
@@ -15,7 +15,7 @@ end
 
 Returns whether an [`Entity`](@ref) is the zero entity.
 """
-@inline function is_zero(entity::Entity)::Bool
+function is_zero(entity::Entity)::Bool
     return entity._id == 1
 end
 

--- a/src/mask.jl
+++ b/src/mask.jl
@@ -33,27 +33,27 @@ function _Mask(bits::Integer...)
     return _Mask(chunks)
 end
 
-@inline function _get_bit(mask::_Mask, i::UInt8)::Bool
+function _get_bit(mask::_Mask, i::UInt8)::Bool
     chunk = (i - 1) >>> 6        # which UInt64 (0-based)
     offset = (i - 1) & 0x3F       # which bit within that UInt64
     return (mask.bits[chunk+1] >> offset) & 0x1 == 1
 end
 
-@inline function _contains_all(mask1::_Mask, mask2::_Mask)::Bool
+function _contains_all(mask1::_Mask, mask2::_Mask)::Bool
     return (mask1.bits[1] & mask2.bits[1]) == mask2.bits[1] &&
            (mask1.bits[2] & mask2.bits[2]) == mask2.bits[2] &&
            (mask1.bits[3] & mask2.bits[3]) == mask2.bits[3] &&
            (mask1.bits[4] & mask2.bits[4]) == mask2.bits[4]
 end
 
-@inline function _contains_any(mask1::_Mask, mask2::_Mask)::Bool
+function _contains_any(mask1::_Mask, mask2::_Mask)::Bool
     return (mask1.bits[1] & mask2.bits[1]) != 0 ||
            (mask1.bits[2] & mask2.bits[2]) != 0 ||
            (mask1.bits[3] & mask2.bits[3]) != 0 ||
            (mask1.bits[4] & mask2.bits[4]) != 0
 end
 
-@inline function _and(a::_Mask, b::_Mask)::_Mask
+function _and(a::_Mask, b::_Mask)::_Mask
     return _Mask((
         a.bits[1] & b.bits[1],
         a.bits[2] & b.bits[2],
@@ -62,7 +62,7 @@ end
     ))
 end
 
-@inline function _or(a::_Mask, b::_Mask)::_Mask
+function _or(a::_Mask, b::_Mask)::_Mask
     return _Mask((
         a.bits[1] | b.bits[1],
         a.bits[2] | b.bits[2],

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -42,7 +42,7 @@ function _recycle(p::_EntityPool, e::Entity)
     p.available += 1
 end
 
-@inline function _is_alive(p::_EntityPool, e::Entity)::Bool
+function _is_alive(p::_EntityPool, e::Entity)::Bool
     return e._gen == p.entities[e._id]._gen
 end
 

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -29,19 +29,19 @@ function _ComponentStorage{C}(archetypes::Int) where C
     _ComponentStorage{C}(Vector{Union{Nothing,Column{C}}}(nothing, archetypes))
 end
 
-@inline function Base.getindex(c::Column, i::Integer)
+function Base.getindex(c::Column, i::Integer)
     return c._data[i]
 end
 
-@inline function Base.setindex!(c::Column, value, i::Integer)
+function Base.setindex!(c::Column, value, i::Integer)
     c._data[i] = value
 end
 
-@inline function Base.length(c::Column)
+function Base.length(c::Column)
     return length(c._data)
 end
 
-@inline Base.eachindex(c::Column) = eachindex(c._data)
-@inline Base.enumerate(c::Column) = enumerate(c._data)
-@inline Base.iterate(c::Column) = iterate(c._data)
-@inline Base.iterate(c::Column, state) = iterate(c._data, state)
+Base.eachindex(c::Column) = eachindex(c._data)
+Base.enumerate(c::Column) = enumerate(c._data)
+Base.iterate(c::Column) = iterate(c._data)
+Base.iterate(c::Column, state) = iterate(c._data, state)

--- a/src/world.jl
+++ b/src/world.jl
@@ -44,11 +44,11 @@ end
     return id
 end
 
-@inline function _get_storage(world::World, id::UInt8, ::Type{C})::_ComponentStorage{C} where C
+function _get_storage(world::World, id::UInt8, ::Type{C})::_ComponentStorage{C} where C
     return _cast_to(_ComponentStorage{C}, world._storages[id])
 end
 
-@inline function _get_storage(world::World, ::Type{C})::_ComponentStorage{C} where C
+function _get_storage(world::World, ::Type{C})::_ComponentStorage{C} where C
     id = _component_id!(world, C)
     return _get_storage(world, id, C)
 end
@@ -182,7 +182,7 @@ end
 
 Returns whether an [`Entity`](@ref) is alive.
 """
-@inline function is_alive(world::World, entity::Entity)::Bool
+function is_alive(world::World, entity::Entity)::Bool
     return _is_alive(world._entity_pool, entity)
 end
 


### PR DESCRIPTION
This is more to express my interest in the project, great work!

Inlining is done by the compiler well by the compiler for small functions. So no need to add them. I was very conservative and not removed for some slightly bigger cases.
