### PR TITLE
Add initial capacity world argument

### DIFF
--- a/src/archetype.jl
+++ b/src/archetype.jl
@@ -7,12 +7,12 @@ struct _Archetype
     id::UInt32
 end
 
-function _Archetype(id::UInt32, node::_GraphNode)
-    _Archetype(Entities(), Vector{UInt8}(), node.mask, node, id)
+function _Archetype(id::UInt32, node::_GraphNode, capacity::UInt32)
+    _Archetype(Entities(capacity), Vector{UInt8}(), node.mask, node, id)
 end
 
-function _Archetype(id::UInt32, node::_GraphNode, components::UInt8...)
-    _Archetype(Entities(), collect(components), node.mask, node, id)
+function _Archetype(id::UInt32, node::_GraphNode, capacity::UInt32, components::UInt8...)
+    _Archetype(Entities(capacity), collect(components), node.mask, node, id)
 end
 
 function _add_entity!(arch::_Archetype, entity::Entity)::UInt32

--- a/src/entity.jl
+++ b/src/entity.jl
@@ -42,11 +42,16 @@ Used in query iteration.
 """
 struct Entities <: AbstractVector{Entity}
     _data::Vector{Entity}
-    Entities() = new(Vector{Entity}())
+
+    function Entities(capacity::UInt32)
+        vec = Vector{Entity}()
+        sizehint!(vec, capacity)
+        new(vec)
+    end
 end
 
-function _new_entities_column()
-    Entities()
+function _new_entities_column(capacity::UInt32)
+    Entities(capacity)
 end
 
 Base.@propagate_inbounds function Base.getindex(c::Entities, i::Integer)

--- a/src/pool.jl
+++ b/src/pool.jl
@@ -5,9 +5,9 @@ mutable struct _EntityPool
     available::UInt32
 end
 
-function _EntityPool(initialCap::UInt32)
+function _EntityPool(initial_capacity::UInt32)
     v = [_new_entity(UInt32(0), typemax(UInt32))]
-    sizehint!(v, initialCap)
+    sizehint!(v, initial_capacity)
 
     return _EntityPool(v, 0, 0)
 end

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -27,8 +27,10 @@ function _add_column!(storage::_ComponentStorage{C}) where {C}
     push!(storage.data, Vector{C}())
 end
 
-function _assign_column!(storage::_ComponentStorage{C}, index::UInt32) where {C}
-    storage.data[index] = Vector{C}()
+function _assign_column!(storage::_ComponentStorage{C}, index::UInt32, capacity::UInt32) where {C}
+    vec = Vector{C}()
+    sizehint!(vec, capacity)
+    storage.data[index] = vec
 end
 
 function _ensure_column_size!(storage::_ComponentStorage{C}, arch::UInt32, needed::UInt32) where {C}

--- a/test/test_entity.jl
+++ b/test/test_entity.jl
@@ -10,7 +10,7 @@
 end
 
 @testset "Entities interface tests" begin
-    col = _new_entities_column()
+    col = _new_entities_column(UInt32(32))
     push!(col._data, _new_entity(1, 0))
     push!(col._data, _new_entity(2, 0))
     push!(col._data, _new_entity(3, 0))

--- a/test/test_world.jl
+++ b/test/test_world.jl
@@ -1,10 +1,11 @@
 
 @testset "World creation" begin
-    world = World()
+    world = World(; initial_capacity=512)
     @test isa(world, World)
     @test isa(world._registry, _ComponentRegistry)
     @test world._storages == ()
     @test length(world._archetypes) == 1
+    @test world._initial_capacity == 512
 end
 
 @testset "World creation 2" begin


### PR DESCRIPTION
I don't understand the performance regression. In the benchmarks, sufficient memory is allocated by a loop in the setup anyway, so it should have no impact at all.