### PR TITLE
Use @inbounds in internal code

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -173,7 +173,7 @@ end
         col = Symbol("col", i)
         push!(exprs, :($stor = map._storage[$i]))
         push!(exprs, :($col = $stor.data[archetype]))
-        push!(exprs, :($col._data[row] = comps[$i]))
+        push!(exprs, :(@inbounds $col._data[row] = comps[$i]))
     end
     return quote
         @inbounds begin

--- a/src/util.jl
+++ b/src/util.jl
@@ -3,7 +3,7 @@ function _swap_remove!(v::Vector, i::UInt32)::Bool
     last_index = length(v)
     swapped = i != last_index
     if swapped
-        v[i] = v[last_index]
+        @inbounds v[i] = v[last_index]
     end
     pop!(v)
     return swapped

--- a/src/world.jl
+++ b/src/world.jl
@@ -119,7 +119,7 @@ function _create_entity!(world::World, archetype_index::UInt32)::Tuple{Entity,UI
     if entity._id > length(world._entities)
         push!(world._entities, _EntityIndex(archetype_index, index))
     else
-        world._entities[entity._id] = _EntityIndex(archetype_index, index)
+        @inbounds world._entities[entity._id] = _EntityIndex(archetype_index, index)
     end
     return entity, index
 end
@@ -483,7 +483,7 @@ end
 
         push!(exprs, :($stor_sym = _get_storage(world, Val{$(QuoteNode(T))}())))
         push!(exprs, :($col_sym = $stor_sym.data[archetype]))
-        push!(exprs, :($col_sym._data[row] = $val_expr))
+        push!(exprs, :(@inbounds $col_sym._data[row] = $val_expr))
     end
 
     push!(exprs, Expr(:return, :nothing))


### PR DESCRIPTION
Looks like the compiler was already able to see that, except for map add/remove, where the assignment is far away from the resize.