### PR TITLE
Get rid of Int conversions

### DIFF
--- a/src/archetype.jl
+++ b/src/archetype.jl
@@ -15,7 +15,7 @@ function _Archetype(id::UInt32, node::_GraphNode, components::UInt8...)
     _Archetype(Entities(), collect(components), node.mask, node, id)
 end
 
-function _add_entity!(arch::_Archetype, entity::Entity)::UInt32
+function _add_entity!(arch::_Archetype, entity::Entity)::Int
     push!(arch.entities._data, entity)
     return length(arch.entities)
 end

--- a/src/entity.jl
+++ b/src/entity.jl
@@ -28,6 +28,6 @@ function _new_entity(id::Int, gen::Int)
 end
 
 struct _EntityIndex
-    archetype::UInt32
-    row::UInt32
+    archetype::Int
+    row::Int
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -154,8 +154,8 @@ end
         col = Symbol("col", i)
         val = Symbol("v", i)
         push!(exprs, :($stor = map._storage.$i))
-        push!(exprs, :(@inbounds $col = $stor.data[Int(index.archetype)]))
-        push!(exprs, :(@inbounds $val = $col._data[Int(index.row)]))
+        push!(exprs, :(@inbounds $col = $stor.data[index.archetype]))
+        push!(exprs, :(@inbounds $val = $col._data[index.row]))
     end
     vals = [Symbol("v", i) for i in 1:N]
     push!(exprs, Expr(:return, Expr(:tuple, vals...)))
@@ -166,14 +166,14 @@ end
     end
 end
 
-@generated function _set_entity_values!(map::Map{W,CS,N}, archetype::UInt32, row::UInt32, comps::Tuple) where {W<:World,CS<:Tuple,N}
+@generated function _set_entity_values!(map::Map{W,CS,N}, archetype::Int, row::Int, comps::Tuple) where {W<:World,CS<:Tuple,N}
     exprs = Expr[]
     for i in 1:N
         stor = Symbol("stor", i)
         col = Symbol("col", i)
         push!(exprs, :($stor = map._storage.$i))
-        push!(exprs, :(@inbounds $col = $stor.data[Int(archetype)]))
-        push!(exprs, :(@inbounds $col._data[Int(row)] = comps.$i))
+        push!(exprs, :(@inbounds $col = $stor.data[archetype]))
+        push!(exprs, :(@inbounds $col._data[row] = comps.$i))
     end
     return quote
         @inbounds begin
@@ -188,7 +188,7 @@ end
         stor = Symbol("stor", i)
         col = Symbol("col", i)
         push!(exprs, :($stor = map._storage.$i))
-        push!(exprs, :(@inbounds $col = $stor.data[Int(index.archetype)]))
+        push!(exprs, :(@inbounds $col = $stor.data[index.archetype]))
         push!(exprs, :(
             if $col === nothing
                 return false

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -7,25 +7,25 @@ function _ComponentStorage{C}(archetypes::Int) where C
     _ComponentStorage{C}(Vector{Union{Nothing,Column{C}}}(nothing, archetypes))
 end
 
-function _assign_column!(storage::_ComponentStorage{C}, index::UInt32) where {C}
-    storage.data[Int(index)] = _new_column(C)
+function _assign_column!(storage::_ComponentStorage{C}, index::Int) where {C}
+    storage.data[index] = _new_column(C)
 end
 
-function _ensure_column_size!(storage::_ComponentStorage{C}, arch::UInt32, needed::UInt32) where {C}
-    col = storage.data[Int(arch)]
+function _ensure_column_size!(storage::_ComponentStorage{C}, arch::Int, needed::Int) where {C}
+    col = storage.data[arch]
     if length(col._data) < needed
         resize!(col._data, needed)
     end
 end
 
-function _move_component_data!(s::_ComponentStorage{C}, old_arch::UInt32, new_arch::UInt32, row::UInt32) where C
-    old_vec = s.data[Int(old_arch)]
-    new_vec = s.data[Int(new_arch)]
-    push!(new_vec._data, old_vec[Int(row)])
+function _move_component_data!(s::_ComponentStorage{C}, old_arch::Int, new_arch::Int, row::Int) where C
+    old_vec = s.data[old_arch]
+    new_vec = s.data[new_arch]
+    push!(new_vec._data, old_vec[row])
     _swap_remove!(old_vec._data, row)
 end
 
-function _remove_component_data!(s::_ComponentStorage{C}, arch::UInt32, row::UInt32) where C
-    col = s.data[Int(arch)]
+function _remove_component_data!(s::_ComponentStorage{C}, arch::Int, row::Int) where C
+    col = s.data[arch]
     _swap_remove!(col._data, row)
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,5 @@
 
-function _swap_remove!(v::Vector, i::UInt32)::Bool
+function _swap_remove!(v::Vector, i::Int)::Bool
     last_index = length(v)
     swapped = i != last_index
     if swapped

--- a/test/test_world.jl
+++ b/test/test_world.jl
@@ -147,7 +147,7 @@ end
     entity, index = _create_entity!(world, arch_index)
     @test entity == _new_entity(2, 0)
     @test index == 1
-    @test world._entities == [_EntityIndex(typemax(UInt32), 0), _EntityIndex(arch_index, UInt32(1))]
+    @test world._entities == [_EntityIndex(typemax(Int), 0), _EntityIndex(arch_index, 1)]
 
     remove_entity!(world, entity)
     entity, index = _create_entity!(world, arch_index)


### PR DESCRIPTION
Should we do this? It simplfies the code but makes `_EntityIndex` larger. However, it seemingly has no effect on performance (was hoping for some additional compiler optimizations by the simplification).