### PR TITLE
Update Julia and FunctionWrappers compatibility version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 FunctionWrappers = "1"
 StaticArrays = "1"
-julia = "1.12"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"


### PR DESCRIPTION
I guess there was no particular reason to require the past minimum version