### PR TITLE
Benchmark thread-safe world lock

### DIFF
--- a/benchmark/internal/bench_lock_unlock.jl
+++ b/benchmark/internal/bench_lock_unlock.jl
@@ -1,4 +1,4 @@
-using Ark: _Lock, _lock, _unlock
+using Ark: _Lock, _lock, _unlock, _lock_safe, _unlock_safe
 
 function setup_lock_unlock(n::Int)
     lock = _Lock()
@@ -19,3 +19,23 @@ end
 
 SUITE["benchmark_lock_unlock n=1000"] =
     @be setup_lock_unlock(1000) benchmark_lock_unlock(_, 1000) seconds = SECONDS
+
+function setup_lock_unlock_safe(n::Int)
+    lock = _Lock()
+    l = _lock_safe(lock)
+    _unlock_safe(lock, l)
+
+    return lock
+end
+
+function benchmark_lock_unlock_safe(args, n)
+    lock = args
+    for i in 1:n
+        l = _lock_safe(lock)
+        _unlock_safe(lock, l)
+    end
+    return lock
+end
+
+SUITE["benchmark_lock_unlock_safe n=1000"] =
+    @be setup_lock_unlock_safe(1000) benchmark_lock_unlock_safe(_, 1000) seconds = SECONDS

--- a/src/lock.jl
+++ b/src/lock.jl
@@ -1,15 +1,24 @@
 mutable struct _Lock
     const pool::_BitPool
     lock_bits::UInt64
+    thread_lock::ReentrantLock
 end
 
 function _Lock()
-    _Lock(_BitPool(), 0)
+    _Lock(_BitPool(), 0, ReentrantLock())
 end
 
 function _lock(lock::_Lock)::Int
     l = _get_bit(lock.pool)
     lock.lock_bits |= UInt64(1) << ((l - 1) % UInt64)
+    return l
+end
+
+function _lock_safe(lo::_Lock)::Int
+    l = 0
+    lock(lo.thread_lock)
+    l = _lock(lo)
+    unlock(lo.thread_lock)
     return l
 end
 
@@ -24,6 +33,22 @@ function _unlock(lock::_Lock, b::Int)
     end
     lock.lock_bits &= ~(UInt64(1) << ((b - 1) % UInt64))
     _recycle(lock.pool, b)
+end
+
+function _unlock_safe(lo::_Lock, b::Int)
+    lock(lo.thread_lock)
+    if ((lo.lock_bits >> (b - 1)) & 0x01) == 0
+        unlock(lo.thread_lock)
+        throw(
+            InvalidStateException(
+                "unbalanced unlock. Did you close a query that was already iterated?",
+                :unbalanced_lock,
+            ),
+        )
+    end
+    lo.lock_bits &= ~(UInt64(1) << (b - 1))
+    _recycle(lo.pool, b)
+    unlock(lo.thread_lock)
 end
 
 function _is_locked(lock::_Lock)::Bool


### PR DESCRIPTION
A test for thread-safe queries.

The overhead seems quite large. So it is questionable whether we should really use this for queries (and only queries) by default. Alternatively, queries could have an additional kwarg to enable this.