### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/src/manual/components.md
+++ b/docs/src/manual/components.md
@@ -10,7 +10,7 @@ one component of a certain type.
 
 In Ark, any type can be used as a component.
 However, it is highly recommended to use immutable types,
-because all mutable objects are allocated on the heap in Julia,
+because mutable objects are usually allocated on the heap in Julia,
 which defeats Ark's claim of high performance.
 Immutable types are disallowed by default, but can be enabled when constructing a [World](@ref)
 by the optional argument `allow_mutable` of the [world constructor](@ref World(::Type...; ::Bool)).
@@ -76,7 +76,7 @@ add_components!(world, entity, (Position(0, 0), Velocity(1,1)))
 
 ```
 
-Note that adding an already existing component of removing a missing one results in an error.
+Note that adding an already existing component or removing a missing one results in an error.
 
 Also note that it is more efficient to add/remove multiple components at once instead of one by one.
 To allow for efficient exchange of components (i.e. add some and remove others in the same operation),

--- a/docs/src/manual/queries.md
+++ b/docs/src/manual/queries.md
@@ -54,7 +54,7 @@ In the outer loop, the query iterates the [archetypes](@ref Architecture),
 and for each one returns a vector of entities and the columns for the queried components.
 In the inner loop, we iterate over the entities within the archetype and perform the actual logic.
 
-Also not the last line in the inner loop. Here, we assign a new `Position` value to the current entity.
+Also note the last line in the inner loop. Here, we assign a new `Position` value to the current entity.
 This is necessary as `Position` is immutable, which is the default and highly recommended.
 See section [Component types](@ref) for details.
 
@@ -181,9 +181,9 @@ entity creation and removal and component addition and removal.
 This is necessary to prevent changes to the inner storage structure of the World
 that would result in undefined behavior of the query.
 
-If the necessity for these forbidden iteration arises,
-the respective entities must be collected into a `Vector` to apply the
-operations after query iteration has finished.
+Whenever the game or model logic demands one of these forbidden operations,
+the entities to be affected must first be collected into a `Vector`, and the
+operations must be applied only after the query iteration has finished.
 
 ```jldoctest; output = false
 # vector for entities to be removed from te world

--- a/docs/src/manual/systems.md
+++ b/docs/src/manual/systems.md
@@ -1,7 +1,7 @@
 # Systems
 
 Ark provides **no systems** as they are widely known in ECS implementations.
-This is a deliberate decisions, based on these reasons:
+This is a deliberate decision, based on these reasons:
 
 - Systems can be hard to integrate into frameworks, like a game engine's update loop.  
   Ark wants to stay flexible and is completely engine-agnostic.
@@ -34,7 +34,7 @@ end
 
 ### Abstract system type
 
-We write and abstract system type.
+We write an abstract system type.
 This is optional, but useful for clarity and to avoid boilerplate.
 
 ```jldoctest systems; output = false
@@ -114,8 +114,7 @@ As we have the abstract type, we only need to implement the functions that are r
 And here the classical movement system:
 
 ```jldoctest systems; output = false
-struct MovementSystem <: System
-end
+struct MovementSystem <: System end
 
 function update!(s::InitializerSystem, w::World)
     for (entities, positions, velocities) in @Query(world, (Position, Velocity))

--- a/docs/src/manual/world.md
+++ b/docs/src/manual/world.md
@@ -1,7 +1,7 @@
 # The World
 
 A [World](@ref world-api) is the central data store for any application that uses Ark.jl.
-It managed [Entities](@ref), [Components](@ref) and [Resources](@ref),
+It manages [Entities](@ref), [Components](@ref) and [Resources](@ref),
 and all these are always tied to a World.
 
 Most applications will have exactly one world, but multiple worlds can exist at the same time.
@@ -30,7 +30,7 @@ world = World(Position, Velocity)
 
 ```
 
-This may seem usual, but it allows Ark to leverage Julia's compile-time programming
+This may seem unusual, but it allows Ark to leverage Julia's compile-time programming
 features for the best performance.
 
 ## World functionality


### PR DESCRIPTION
This corrects some typos I noticed along the way.

l also slightly weakened the claim about heap allocations, as in principle the compiler is allowed to elide allocations if it can prove they don't escape.