### PR TITLE
Bump FieldViews.jl compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-FieldViews = "0.3.1"
+FieldViews = "0.3.2"
 FunctionWrappers = "1"
 StaticArrays = "1"
 julia = "1.10"


### PR DESCRIPTION
This includes an important bugfix so it'd be good to not let the old version be used: https://github.com/MasonProtter/FieldViews.jl/pull/9