### PR TITLE
Inline ensure column size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.json
 *.json.tmp
 *.mem
+*.pb.gz
 
 *.csv
 *.html

--- a/src/world.jl
+++ b/src/world.jl
@@ -429,7 +429,7 @@ end
     index = _add_entity!(table, entity)
 
     for comp in archetype.components
-        _ensure_column_size_for_comp!(world, comp, table_index, index)
+        @inline _ensure_column_size_for_comp!(world, comp, table_index, index)
     end
 
     if entity._id > length(world._entities)


### PR DESCRIPTION
This improves the `copy entity` benchmark quite a bit, but it also makes the large world tests take ages. Could it be that inlining a generated function (into an ordinary function that is in turn inlined) into a generated function explodes the total number of methods?

BTW, the slowdown is the higher, the newer the Julia version:

- LTS: 6m
- 1.12: 26m
- pre: >1h (unknown)