### PR TITLE
Restrict CI workflow to main branch on push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - main
     tags: ['*']
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
I see duplicated tests in #483, this was introduced in #484 