### PR TITLE
Remove inbounds to _is_alive function

### DIFF
--- a/src/pool.jl
+++ b/src/pool.jl
@@ -42,10 +42,7 @@ function _recycle(p::_EntityPool, e::Entity)
 end
 
 function _is_alive(p::_EntityPool, e::Entity)::Bool
-    if e._id > length(p.entities)
-        return false
-    end
-    return @inbounds e._gen == p.entities[e._id]._gen
+    return e._gen == p.entities[e._id]._gen
 end
 
 function _reset!(p::_EntityPool)


### PR DESCRIPTION
This function was unsafe before and could cause UB since it is called directly from the public `is_alive`