### PR TITLE
fix: replace dead entity references with zero_entity in _cleanup_archetypes

### DIFF
--- a/src/world.jl
+++ b/src/world.jl
@@ -1229,6 +1229,15 @@ function _cleanup_archetypes(world::World, entity::Entity)
                         mask)
                 end
 
+                # Replace any dead entity references (other than zero_entity) with zero_entity.
+                # This can happen when batch-removing entities that are relation targets of each other.
+                for i in eachindex(new_relations)
+                    rel = new_relations[i]
+                    if !is_zero(rel.second) && !is_alive(world, rel.second)
+                        new_relations[i] = Pair(rel.first, zero_entity)
+                    end
+                end
+
                 new_table, found = _get_table(world, archetype, new_relations)
                 if !found
                     new_table_id = _create_table!(world, archetype, copy(new_relations))


### PR DESCRIPTION
## Problem

`remove_entities!` fails when the entities being removed are relation targets of *other* entities that are also being removed.

**Minimal reproduction:**
```julia
using Ark

struct Tag end
struct R1 <: Relationship end
struct R2 <: Relationship end

w = World(Tag, R1, R2)
p1 = new_entity!(w, (Tag(),))
p2 = new_entity!(w, (Tag(),))
child = new_entity!(w, (R1(), R2(); relations=(R1 => p1, R2 => p2)))

remove_entities!(w, Filter(w, (Tag,)))  # ERROR
```

Error:
```
ArgumentError: can't use a dead entity as relation target, except for the zero entity
```

## Root Cause

In `_cleanup_archetypes`, `_get_exchange_targets_unchecked()` returns `new_relations` containing entity IDs of other entities that are also being deleted in the same batch. These dead entity references are passed to `_create_table!`, which validates all relation targets via `_check_relation_targets` and throws because the entities are dead (but not `zero_entity`).

## Fix

After `_get_exchange_targets_unchecked` returns, scan `new_relations` and replace any dead entity references (that are not already `zero_entity`) with `zero_entity` before calling `_get_table` / `_create_table!`.

```julia
for i in eachindex(new_relations)
    rel = new_relations[i]
    if !is_zero(rel.second) && !is_alive(world, rel.second)
        new_relations[i] = Pair(rel.first, zero_entity)
    end
end
```

## Testing

The fix allows the MWE above to succeed. Relations pointing to removed entities are correctly replaced with `zero_entity`, matching the expected ECS semantics.

Fixes #606
